### PR TITLE
Update logic of checking real time protection status (ticket Windows …

### DIFF
--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-1.12.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-1.12.0#RegistrySettings.ps1
@@ -12652,14 +12652,10 @@ $hyperVStatus = CheckHyperVStatus
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
-                -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
-        
-            if ($regValue -ne 0) {
+            $status = Get-MpComputerStatus
+            if ($status.RealTimeProtectionEnabled -ne $true) {
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: 0"
+                    Message = "Real-time protection is not activated."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-1.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-1.0.0#RegistrySettings.ps1
@@ -12557,14 +12557,10 @@ $hyperVStatus = CheckHyperVStatus
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
-                -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
-        
-            if ($regValue -ne 0) {
+            $status = Get-MpComputerStatus
+            if ($status.RealTimeProtectionEnabled -ne $true) {
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: 0"
+                    Message = "Real-time protection is not activated."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-CIS-1.3.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-CIS-1.3.0#RegistrySettings.ps1
@@ -9465,14 +9465,10 @@ $hyperVStatus = CheckHyperVStatus
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
-                -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
-        
-            if ($regValue -ne 0) {
+            $status = Get-MpComputerStatus
+            if ($status.RealTimeProtectionEnabled -ne $true) {
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: 0"
+                    Message = "Real-time protection is not activated."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-CIS-1.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-CIS-1.0.0#RegistrySettings.ps1
@@ -9447,14 +9447,10 @@ $hyperVStatus = CheckHyperVStatus
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
-                -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
-        
-            if ($regValue -ne 0) {
+            $status = Get-MpComputerStatus
+            if ($status.RealTimeProtectionEnabled -ne $true) {
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: 0"
+                    Message = "Real-time protection is not activated."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/RSSeverityTests.ps1
+++ b/ATAPAuditor/AuditGroups/RSSeverityTests.ps1
@@ -545,15 +545,11 @@ $hyperVStatus = CheckHyperVStatus
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
-                -Name "DisableRealtimeMonitoring" `
-            | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
-        
-            if ($regValue -eq 1) {
+            $status = Get-MpComputerStatus
+            if ($status.RealTimeProtectionEnabled -ne $true) {
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: 0"
-                    Status  = "False"
+                    Message = "Real-time protection is not activated."
+                    Status = "False"
                 }
             }
         }


### PR DESCRIPTION
based on question from ticket #225, logic has been updated to check real-time protection status via cmdlet Get-MpComputerStatus instead of checking via registry. Please validate changes and close ticket, merge request, and delete branch if you approve these changes.