### PR TITLE
Fix Bug#258: Add answers when no dates are found

### DIFF
--- a/ATAPAuditor/AuditGroups/Windows Base Security.ps1
+++ b/ATAPAuditor/AuditGroups/Windows Base Security.ps1
@@ -333,7 +333,14 @@ function hasTPM {
 	Task = "Check if the last successful search for updates was in the past 24 hours."
 	Test = {
 		try {
-			$tdiff = New-TimeSpan -ErrorAction Stop -Start (New-Object -com "Microsoft.Update.AutoUpdate").Results.LastSearchSuccessDate -End (Get-Date)
+			$startdate = (New-Object -com "Microsoft.Update.AutoUpdate").Results.LastSearchSuccessDate
+			if ($null -eq $startdate) {
+				return @{
+					Message = "There was no search found."
+					Status = "False"
+				}
+			}
+			$tdiff = New-TimeSpan -ErrorAction Stop -Start $startdate -End (Get-Date)
 			$status = switch ($tdiff.Hours) {
 				{($PSItem -ge 0) -and ($PSItem -le 24)}{
 					@{
@@ -369,7 +376,14 @@ function hasTPM {
 	Task = "Check if the last successful installation of updates was in the past 5 days." # Windows defender definitions do count as updates
 	Test = {
 		try{
-			$tdiff = New-TimeSpan -Start (New-Object -com "Microsoft.Update.AutoUpdate").Results.LastInstallationSuccessDate -End (Get-Date)
+			$startdate = (New-Object -com "Microsoft.Update.AutoUpdate").Results.LastInstallationSuccessDate
+			if ($null -eq $startdate) {
+				return @{
+					Message = "There was no date found."
+					Status = "False"
+				}
+			}
+			$tdiff = New-TimeSpan -Start $startdate -End (Get-Date)
 			$status = switch ($tdiff.Hours) {
 				{($PSItem -ge 0) -and ($PSItem -le 24*5)}{
 					@{


### PR DESCRIPTION
#258 
Fix has been done by catching $null returns from "Autoupdate-Object" and giving proper auditcheck outputs -> resulting to False.