### PR TITLE
Update #292 License logic check

### DIFF
--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -128,7 +128,7 @@ function Test-ArrayEqual {
 }
 
 function Get-LicenseStatus{
-	$licenseStatus = (Get-CIMInstance -query "select Name, Description, LicenseStatus from SoftwareLicensingProduct where LicenseStatus=1").LicenseStatus
+	$licenseStatus = (Get-CimInstance SoftwareLicensingProduct -Filter "Name like 'Windows%'" | where { $_.PartialProductKey } | select Description, LicenseStatus -ExpandProperty LicenseStatus)
 	switch($licenseStatus){
 		"0" {$lcStatus = "Unlicensed"}
 		"1" {$lcStatus = "Licensed"}


### PR DESCRIPTION
#292. License logic check has been updated. The old check only returned a value if the system was licensed, but wouldn't return anything else if the system is something other than licensed.