### PR TITLE
Fix message of AuditTest revise check for (BL) Ensure 'Allow access to BitLocker-protected fixed data drives from earlier versions of Windows' is set to 'Disabled' #389

### DIFF
--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-BSI-Bundespolizei#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-BSI-Bundespolizei#RegistrySettings.ps1
@@ -5297,8 +5297,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-2.0.0#RegistrySettings.ps1
@@ -9501,8 +9501,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-CIS-2.0.0#RegistrySettings.ps1
@@ -10476,8 +10476,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "RDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-1.0.1#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-1.0.1#RegistrySettings.ps1
@@ -8137,8 +8137,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-2.0.0#RegistrySettings.ps1
@@ -9537,8 +9537,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ' '"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-2.0.0#RegistrySettings.ps1
@@ -10511,12 +10511,15 @@ $windefrunning = CheckWindefRunning
                 -Name "RDVDiscoveryVolumeType" `
                 | Select-Object -ExpandProperty "RDVDiscoveryVolumeType"
         
-            if ($regValue -ne "") {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: ' '"
-                    Status = "False"
+                if ($regValue -ne "") {
+                    if($regValue -eq "<none>"){
+                        $regValue = "&lt;none&gt;"
+                    }
+                    return @{
+                        Message = "Registry value is '$regValue'. Expected: This value should be empty."
+                        Status = "False"
+                    }
                 }
-            }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-Stand-alone-CIS-1.0.1#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-Stand-alone-CIS-1.0.1#RegistrySettings.ps1
@@ -8097,8 +8097,11 @@ $windefrunning = CheckWindefRunning
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 7-CIS-3.1.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 7-CIS-3.1.0#RegistrySettings.ps1
@@ -6225,8 +6225,11 @@ $RootPath = Split-Path $RootPath -Parent
                 | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
+                if($regValue -eq "<none>"){
+                    $regValue = "&lt;none&gt;"
+                }
                 return @{
-                    Message = "Registry value is '$regValue'. Expected: ''"
+                    Message = "Registry value is '$regValue'. Expected: This value should be empty."
                     Status = "False"
                 }
             }


### PR DESCRIPTION
Ticket #389. Please review changes.