### PR TITLE
Remove AuditTest from MS AuditGroups Remove "Set registry value 'PolicyVersion' to 538." from ALL MS Benchmarks #408

### DIFF
--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-Microsoft-21H1#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-Microsoft-21H1#RegistrySettings.ps1
@@ -4143,42 +4143,6 @@ $hyperVStatus = CheckHyperVStatus
     }
 }
 [AuditTest] @{
-    Id = "Registry-104"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-105"
     Task = "Domain: Set registry value 'DefaultOutboundAction' to 0."
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-2022#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-2022#RegistrySettings.ps1
@@ -4128,42 +4128,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-110"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-111"
     Task = "Set registry value 'DefaultOutboundAction' to 'Disabled'."
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016 Domain Controller-Microsoft-FINAL#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016 Domain Controller-Microsoft-FINAL#RegistrySettings.ps1
@@ -1298,42 +1298,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-050"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-051"
     Task = "Domain: Set registry value 'DefaultOutboundAction' to 0."
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016-Microsoft-FINAL#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016-Microsoft-FINAL#RegistrySettings.ps1
@@ -1406,42 +1406,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-040"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-041"
     Task = "Domain: Set registry value 'DefaultOutboundAction' to 0."
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019 Domain Controller-Microsoft-FINAL#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019 Domain Controller-Microsoft-FINAL#RegistrySettings.ps1
@@ -2648,42 +2648,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-078"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-079"
     Task = "Domain: Set registry value 'DefaultOutboundAction' to 0."
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-Microsoft-FINAL#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-Microsoft-FINAL#RegistrySettings.ps1
@@ -7542,42 +7542,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-209"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-210"
     Task = "Set registry value 'DefaultOutboundAction' to 0. (DomainProfile)"
     Constraints = @(

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-Microsoft-FINAL#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-Microsoft-FINAL#RegistrySettings.ps1
@@ -8464,42 +8464,6 @@ $windefrunning = CheckWindefRunning
     }
 }
 [AuditTest] @{
-    Id = "Registry-374"
-    Task = "Set registry value 'PolicyVersion' to 538."
-    Test = {
-        try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall" `
-                -Name "PolicyVersion" `
-                | Select-Object -ExpandProperty "PolicyVersion"
-        
-            if ($regValue -ne 538) {
-                return @{
-                    Message = "Registry value is '$regValue'. Expected: 538"
-                    Status = "False"
-                }
-            }
-        }
-        catch [System.Management.Automation.PSArgumentException] {
-            return @{
-                Message = "Registry value not found."
-                Status = "False"
-            }
-        }
-        catch [System.Management.Automation.ItemNotFoundException] {
-            return @{
-                Message = "Registry key not found."
-                Status = "False"
-            }
-        }
-        
-        return @{
-            Message = "Compliant"
-            Status = "True"
-        }
-    }
-}
-[AuditTest] @{
     Id = "Registry-375"
     Task = "Domain: Set registry value 'DefaultOutboundAction' to 0."
     Constraints = @(


### PR DESCRIPTION
Ticket #408. Please review changes.