### PR TITLE
Fix typo in registry path Wrong registry path for "Configure validation of ROCA-vulnerable WHfB keys during authentication" #599

### DIFF
--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2012 R2-CIS-2.6.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2012 R2-CIS-2.6.0#RegistrySettings.ps1
@@ -6430,7 +6430,7 @@ try {
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ SAM" `
+                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\SAM" `
                 -Name "SamNGCKeyROCAValidation" `
                 | Select-Object -ExpandProperty "SamNGCKeyROCAValidation"
         

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2016-CIS-2.0.0#RegistrySettings.ps1
@@ -7385,7 +7385,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ SAM" `
+                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\SAM" `
                 -Name "SamNGCKeyROCAValidation" `
                 | Select-Object -ExpandProperty "SamNGCKeyROCAValidation"
         

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2019-CIS-2.0.0#RegistrySettings.ps1
@@ -7492,7 +7492,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ SAM" `
+                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\SAM" `
                 -Name "SamNGCKeyROCAValidation" `
                 | Select-Object -ExpandProperty "SamNGCKeyROCAValidation"
         

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2022-CIS-2.0.0#RegistrySettings.ps1
@@ -7582,7 +7582,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ SAM" `
+                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\SAM" `
                 -Name "SamNGCKeyROCAValidation" `
                 | Select-Object -ExpandProperty "SamNGCKeyROCAValidation"
         


### PR DESCRIPTION
Ticket solved (#599). Please review changes.