### PR TITLE
removed feature to open a 5.1 powershell session

### DIFF
--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -896,13 +896,8 @@ function Save-ATAPHtmlReport {
 		$psVersion = $PSVersionTable.PSVersion
 		#PowerShell Major version not 5.*
 		if (($psVersion.Major -ne 5)) {
-			Write-Warning "ATAPAuditor is only compatible with PowerShell Version 5.1. Your version is $psVersion. Do you want to open a Powershell 5? Y/N"
-			$in = Read-Host
-			switch ($in) {
-				Y { Start Powershell; return }
-				N { Write-Warning "Stopping Script..."; return }
-				default { Write-Warning "You did not choose Y nor N. Stopping Script..."; return }
-			}
+			Write-Warning "ATAPAuditor is only compatible with PowerShell Version 5.1. Your version is $psVersion. Please open a PowerShell Version 5.1 session to continue!"
+			return;
 		}
 		#PowerShell version not 5.1
 		if (($psVersion.Major -eq 5) -and ($psVersion.Minor -eq 0)) {


### PR DESCRIPTION
in this ticket now is:
- the feature to open a PS 5.1 session removed
- Write-Warning text is changed