### PR TITLE
Implemented new "slightly" more efficient license check

### DIFF
--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -171,21 +171,8 @@ function Start-ModuleTest {
 }
 
 function Get-LicenseStatus {
-	param(
-		$SkipLicenseCheck
-	)
-	if ($LicenseStatusCache) {
-		return $LicenseStatusCache
-	}
-	
-	if ($SkipLicenseCheck -eq $true) {
-		$LicenseStatusCache = "License check has been skipped."
-		return $LicenseStatusCache
-	}
-	
 	Write-Host "Checking operating system activation status"
 
-	
 	$license = ""
 	# Here we test whether the system is 32 or 64 Bit
 	# Using the 32 Bit version of cscript results in twice the performance when running slmgr
@@ -852,10 +839,6 @@ function Save-ATAPHtmlReport {
 		[Parameter(Mandatory = $false)]
 		[switch]
 		$RiskScore,
-
-		[Parameter(Mandatory = $false)]
-		[switch]
-		$SkipLicenseCheck,
 		# [Parameter(Mandatory = $false)]
 		# [switch]
 		# $MITRE,
@@ -932,7 +915,7 @@ function Save-ATAPHtmlReport {
 	$report = Invoke-ATAPReport -ReportName $ReportName 
 	#hashes for each recommendation
 	if (!$isUnix) {
-		$SystemInformation.SoftwareInformation.LicenseStatus = Get-LicenseStatus $SkipLicenseCheck
+		$SystemInformation.SoftwareInformation.LicenseStatus = Get-LicenseStatus
 	}
 	$hashtable_sha256 = GenerateHashTable $report
 	

--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -182,18 +182,41 @@ function Get-LicenseStatus {
 		$LicenseStatusCache = "License check has been skipped."
 		return $LicenseStatusCache
 	}
+	
+	Write-Host "Checking operating system activation status"
 
-	Write-Host "Checking operating system activation status. This may take a while..."
-	$license = Get-CimInstance SoftwareLicensingProduct -Filter "Name like 'Windows%'" | Where-Object { $_.PartialProductKey } | Select-Object -First 1
-	$LicenseStatusCache = switch ($license.LicenseStatus) {
-		"0" { "Unlicensed" }
-		"1" { "Licensed" }
-		"2" { "OOBGrace" }
-		"3" { "OOTGrace" }
-		"4" { "NonGenuineGrace" }
-		"5" { "Notification" }
-		"6" { "ExtendedGrace" }
+	
+	$license = ""
+	# Here we test whether the system is 32 or 64 Bit
+	# Using the 32 Bit version of cscript results in twice the performance when running slmgr
+	if(Test-Path -Path C:\Windows\SysWOW64){
+		# 64 Bit System, so we specifically use the 32 Bit executable of cscript
+		$license = (C:\Windows\SysWOW64\cscript C:\Windows\System32\slmgr.vbs /xpr)[4]
+	}else{
+		# 32 Bit System
+		$license = (C:\Windows\System32\cscript C:\Windows\System32\slmgr.vbs /xpr)[4]
 	}
+	# Trim it as the output has 4 spaces to the left by default
+	$license = $license.Trim()
+
+	# Since slmgr /xpr outputs license status 2 and 3 with a the end date
+	# we are simply going to match them, and replace the license string with the fixed value
+	if($license -match "(Initial grace period ends)" -or $license -match "(Additional grace period ends)"){
+		$license = $Matches[1]
+	}
+
+	$LicenseStatusCache = switch ($license) {
+		"Unlicensed" { "Unlicensed" }
+		"The machine is permanently activated." { "Licensed" }
+		"Initial grace period ends" { "OOBGrace" }
+		"Additional grace period ends" { "OOTGrace" }
+		"Non-genuine grace period ends" { "NonGenuineGrace" }
+		"Windows is in Notification mode" { "Notification" }
+		"Extended grace period ends" { "ExtendedGrace" }
+	}
+	
+	Write-Host "Operating system activation status retrieved"
+
 	return $LicenseStatusCache
 }
 

--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -184,22 +184,37 @@ function Get-LicenseStatus {
 		$license = (C:\Windows\System32\cscript C:\Windows\System32\slmgr.vbs /xpr)[4]
 	}
 	# Trim it as the output has 4 spaces to the left by default
-	$license = $license.Trim()
+	# The output format for slmgr.vbs /xpr can be a bit hard to work with, so we are going to remove all . and " just to make sure it is clean
+	$license = $license.Trim().Replace(".", "").Replace('"', "")
 
-	# Since slmgr /xpr outputs license status 2 and 3 with a the end date
-	# we are simply going to match them, and replace the license string with the fixed value
-	if($license -match "(Initial grace period ends)" -or $license -match "(Additional grace period ends)"){
-		$license = $Matches[1]
+
+	
+	# Here we check the slmgr ini files (The translation files), compare the output from the command with this list, and then take the key from that string
+	$found 
+	Get-ChildItem C:\Windows\System32\slmgr | ForEach-Object($_){
+        $t1 = Get-Content C:\Windows\System32\slmgr\$_\slmgr.ini | Select-String -pattern "LicenseStatus" 
+        for ($i = 0; $i -lt $t1.Count; $i++) {
+            $t1[$i].Line = $t1[$i].Line.Replace(".", "").Replace('"', "").Replace("%ENDDATE%", "")
+        }
+        $t2 = $t1 | ConvertFrom-StringData
+        for ($i = 0; $i -lt $t2.Count; $i++) {
+            if($license -match $t2[$i].Values){
+                $found = $t2[$i].Keys
+                break
+            }
+        }
 	}
 
-	$LicenseStatusCache = switch ($license) {
-		"Unlicensed" { "Unlicensed" }
-		"The machine is permanently activated." { "Licensed" }
-		"Initial grace period ends" { "OOBGrace" }
-		"Additional grace period ends" { "OOTGrace" }
-		"Non-genuine grace period ends" { "NonGenuineGrace" }
-		"Windows is in Notification mode" { "Notification" }
-		"Extended grace period ends" { "ExtendedGrace" }
+
+	# Here we evaluate our findings, and return the actual name for the license status
+	$LicenseStatusCache = switch ($found) {
+		"L_MsgLicenseStatusUnlicensed" { "Unlicensed" }
+		"L_MsgLicenseStatusLicensed" { "Licensed" }
+		"L_MsgLicenseStatusInitialGrace" { "OOBGrace" }
+		"L_MsgLicenseStatusAdditionalGrace" { "OOTGrace" }
+		"L_MsgLicenseStatusNonGenuineGrace" { "NonGenuineGrace" }
+		"L_MsgLicenseStatusNotification" { "Notification" }
+		"L_MsgLicenseStatusExtendedGrace" { "ExtendedGrace" }
 	}
 	
 	Write-Host "Operating system activation status retrieved"

--- a/ATAPAuditor/AuditGroups/SBD - Windows Base Security.ps1
+++ b/ATAPAuditor/AuditGroups/SBD - Windows Base Security.ps1
@@ -6,17 +6,11 @@ $RootPath = Split-Path $RootPath -Parent
 	Id   = "SBD-201"
 	Task = "Get License status."
 	Test = {
-		$lcStatus = Get-LicenseStatus $SkipLicenseCheck
+		$lcStatus = Get-LicenseStatus
 		if ($lcStatus -eq "Licensed") {
 			return @{
 				Message = "Compliant"
 				Status  = "True"
-			}
-		}
-		if ($lcStatus -eq "License check has been skipped.") {
-			return @{
-				Message = $lcStatus
-				Status  = "None"
 			}
 		}
 		return @{


### PR DESCRIPTION
Implemented a new license check that only takes between 0.3-1 seconds instead of the current implementation that needs about 30 seconds. So far i could only test "Licensed" and "OOTGrace", even tho everything should work the same way as before, it would still be a good idea to test it with different activation states