### PR TITLE
Ticket 776

### DIFF
--- a/ATAPAuditor/AuditGroups/SBD - PowerShell Security.ps1
+++ b/ATAPAuditor/AuditGroups/SBD - PowerShell Security.ps1
@@ -18,25 +18,6 @@
 	Id = "SBD-302"
 	Task = "Ensure PowerShell Version 2 is uninstalled."
 	Test = {
-
-        # $features = @(
-        #     "MicrosoftWindowsPowerShellV2Root",
-        #     "MicrosoftWindowsPowerShellV2"
-        # )
-        # foreach ($feature in $features) {
-        
-        #     $featureInfo = Get-WindowsOptionalFeature -Online -FeatureName $feature -ErrorAction SilentlyContinue
-        
-        #     # Feature does not exist on this system
-        #     if (-not $featureInfo -or
-        #         -not $featureInfo.State -or
-        #         $featureInfo.State -ne 'Enabled') {
-        
-        #         Write-Host "$feature is not available on this system." -ForegroundColor DarkGray
-        #         continue
-        #     }
-        # }
-
         $ps2Found = $false
         $messages = "The following PS2-related features are enabled:"
 

--- a/ATAPAuditor/AuditGroups/SBD - PowerShell Security.ps1
+++ b/ATAPAuditor/AuditGroups/SBD - PowerShell Security.ps1
@@ -18,21 +18,47 @@
 	Id = "SBD-302"
 	Task = "Ensure PowerShell Version 2 is uninstalled."
 	Test = {
+
+        # $features = @(
+        #     "MicrosoftWindowsPowerShellV2Root",
+        #     "MicrosoftWindowsPowerShellV2"
+        # )
+        # foreach ($feature in $features) {
+        
+        #     $featureInfo = Get-WindowsOptionalFeature -Online -FeatureName $feature -ErrorAction SilentlyContinue
+        
+        #     # Feature does not exist on this system
+        #     if (-not $featureInfo -or
+        #         -not $featureInfo.State -or
+        #         $featureInfo.State -ne 'Enabled') {
+        
+        #         Write-Host "$feature is not available on this system." -ForegroundColor DarkGray
+        #         continue
+        #     }
+        # }
+
         $ps2Found = $false
         $messages = "The following PS2-related features are enabled:"
 
-        $PSV2State = (Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2).State
-        if ($PSV2State -eq "Enabled") {
-            $messages += "<br>Windows PowerShell 2.0 Engine"
-            $ps2Found = $true
+        $PSV2Feature = (Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2)
+        if($null -ne $PSV2Feature){
+            $PSV2FeatureState = $PSV2Feature.State
+            if ($PSV2FeatureState -eq "Enabled") {
+                $messages += "<br>Windows PowerShell 2.0 Engine"
+                $ps2Found = $true
+            }
         }
+
 
         $os = Get-CimInstance Win32_OperatingSystem
         if ($os.ProductType -eq 1) {
-            $PSRootState = (Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root).State
-            if ($PSRootState -eq "Enabled") {
-                $messages += "<br>Windows PowerShell 2.0"
-                $ps2Found = $true
+            $PSRootFeature = (Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root)
+            if($null -ne $PSRootFeature){
+                $PSRootState = $PSRootFeature.State
+                if ($PSRootState -eq "Enabled") {
+                    $messages += "<br>Windows PowerShell 2.0"
+                    $ps2Found = $true
+                }
             }
         }
 


### PR DESCRIPTION
Adapted the code to first check whether powershell v2 is installed in the first place before checking the state of it. 
Might require some more testing, as i could not reproduce the initially mentioned error, but the script worked on Windows 10, 11 and Server 2025, where PSv2 was installed on 2 of the listed systems, and not installed on 1 of them.