### PR TITLE
ticket_783

### DIFF
--- a/ATAPAuditor/ATAPAuditor.psm1
+++ b/ATAPAuditor/ATAPAuditor.psm1
@@ -738,10 +738,10 @@ function Get-ATAPReport {
 	)
 	#Windows OS
 	if ([System.Environment]::OSVersion.Platform -ne 'Unix') {
-		return Get-ChildItem "$RootPath\Reports\$ReportName.ps1" | Select-Object -Property BaseName
+		return Get-ChildItem "$RootPath\Reports\*$ReportName*.ps1" | Select-Object -Property BaseName
 	}
 	#Linux OS
-	return Get-ChildItem "$RootPath/Reports/$ReportName.ps1" | Select-Object -Property BaseName
+	return Get-ChildItem "$RootPath/Reports/*$ReportName*.ps1" | Select-Object -Property BaseName
 }
 
 <#


### PR DESCRIPTION
Added wildcards to Get-ATAPReport to imrpove user experience. 
Now the user can run "Get-ATAPReport deb" and will see all available debian benchmarks. 
The wildcards are on both sides, so "wind" will show all "Microsoft Windows" benchmarks.